### PR TITLE
Fix parse of Float input boxes

### DIFF
--- a/app/src/components/ui/FloatInput.tsx
+++ b/app/src/components/ui/FloatInput.tsx
@@ -21,7 +21,7 @@ export const FloatInput = (props: Props) => {
         const value = e.target.value;
         setValue(value);
 
-        if (FLOAT_REGEX.test(value)) props.onChange(parseInt(value));
+        if (FLOAT_REGEX.test(value)) props.onChange(parseFloat(value));
       }}
       onBlur={(e) => {
         if (e.target.value.length === 0) {


### PR DESCRIPTION
Nodes that generate floats currently work fine, but typing a float into the input box manually used parseInt() and as such (eg) 0.55 would output as 0.