### PR TITLE
Standardise node input/output IDs + floor some int outputs

### DIFF
--- a/core/src/packages/discord/api.ts
+++ b/core/src/packages/discord/api.ts
@@ -90,13 +90,13 @@ pkg.createNonEventSchema({
       type: types.string(),
     });
     t.dataInput({
-      id: "channel",
+      id: "channelId",
       name: "Channel ID",
       type: types.string(),
     });
   },
   async run({ ctx }) {
-    await api.channels(ctx.getInput("channel")).messages.post(z.undefined(), {
+    await api.channels(ctx.getInput("channelId")).messages.post(z.undefined(), {
       body: { Json: { content: ctx.getInput("message") } },
     });
   },
@@ -117,17 +117,17 @@ pkg.createNonEventSchema({
       type: types.string(),
     });
     t.dataOutput({
-      id: "display_name",
+      id: "displayName",
       name: "Display Name",
       type: types.string(),
     });
     t.dataOutput({
-      id: "avatar",
+      id: "avatarId",
       name: "Avatar ID",
       type: types.string(),
     });
     t.dataOutput({
-      id: "banner",
+      id: "bannerId",
       name: "Banner ID",
       type: types.string(),
     });
@@ -136,9 +136,9 @@ pkg.createNonEventSchema({
     const response = await api.users(ctx.getInput("userId")).get(USER_SCHEMA);
 
     ctx.setOutput("username", response.username);
-    ctx.setOutput("display_name", response.display_name);
-    ctx.setOutput("avatar", response.avatar);
-    ctx.setOutput("banner", response.banner);
+    ctx.setOutput("displayName", response.display_name);
+    ctx.setOutput("avatarId", response.avatar);
+    ctx.setOutput("bannerId", response.banner);
   },
 });
 
@@ -162,17 +162,17 @@ pkg.createNonEventSchema({
       type: types.string(),
     });
     t.dataOutput({
-      id: "display_name",
+      id: "displayName",
       name: "Display Name",
       type: types.string(),
     });
     t.dataOutput({
-      id: "avatar",
+      id: "avatarId",
       name: "Avatar ID",
       type: types.string(),
     });
     t.dataOutput({
-      id: "banner",
+      id: "bannerId",
       name: "Banner ID",
       type: types.string(),
     });
@@ -194,9 +194,9 @@ pkg.createNonEventSchema({
       .get(GUILD_MEMBER_SCHEMA);
 
     ctx.setOutput("username", response.user.username);
-    ctx.setOutput("display_name", response.user.display_name);
-    ctx.setOutput("avatar", response.user.avatar);
-    ctx.setOutput("banner", response.user.banner);
+    ctx.setOutput("displayName", response.user.display_name);
+    ctx.setOutput("avatarId", response.user.avatar);
+    ctx.setOutput("bannerId", response.user.banner);
     ctx.setOutput("nick", response.nick);
     ctx.setOutput("roles", response.roles);
   },
@@ -212,12 +212,7 @@ pkg.createNonEventSchema({
       type: types.string(),
     });
     t.dataInput({
-      id: "roleId",
-      name: "Role ID",
-      type: types.string(),
-    });
-    t.dataOutput({
-      id: "roleId",
+      id: "roleIdIn",
       name: "Role ID",
       type: types.string(),
     });
@@ -227,7 +222,7 @@ pkg.createNonEventSchema({
       type: types.string(),
     });
     t.dataOutput({
-      id: "roleId",
+      id: "roleIdOut",
       name: "Role ID",
       type: types.string(),
     });
@@ -248,7 +243,7 @@ pkg.createNonEventSchema({
     });
   },
   async run({ ctx }) {
-    let roleId = ctx.getInput("roleId");
+    let roleId = ctx.getInput("roleIdIn");
 
     const roles = await api
       .guilds(ctx.getInput("guildId"))
@@ -259,7 +254,7 @@ pkg.createNonEventSchema({
     if (!role) return;
 
     ctx.setOutput("name", role.name);
-    ctx.setOutput("roleId", role.id);
+    ctx.setOutput("roleIdOut", role.id);
     ctx.setOutput("position", role.position);
     ctx.setOutput("mentionable", role.mentionable);
     ctx.setOutput("permissions", role.permissions);

--- a/core/src/packages/httpRequests.ts
+++ b/core/src/packages/httpRequests.ts
@@ -48,7 +48,9 @@ pkg.createNonEventSchema({
       {
         url: ctx.getInput<string>("url"),
         method: "POST",
-        body: ctx.getInput<string>("body"),
+        body: {
+          Json: ctx.getInput<string>("body"),
+        },
         headers: {
           "content-type": "application/json; charset=UTF-8",
         },
@@ -92,7 +94,9 @@ pkg.createNonEventSchema({
       {
         url: ctx.getInput<string>("url"),
         method: "PUT",
-        body: ctx.getInput<string>("body"),
+        body: {
+          Json: ctx.getInput<string>("body"),
+        },
         headers: {
           "content-type": "application/json; charset=UTF-8",
         },

--- a/core/src/packages/localStorage.ts
+++ b/core/src/packages/localStorage.ts
@@ -1,54 +1,53 @@
 import { core } from "../models";
 import { types } from "../types";
 
-
 const pkg = core.createPackage({
-    name: "Localstorage",
+  name: "Localstorage",
 });
 
 pkg.createNonEventSchema({
-    name: "Set Data",
-    variant: "Exec",
-    generateIO: (t) => {
-        t.dataInput({
-            id: "key",
-            name: "Key",
-            type: types.string(),
-        });
-        t.dataInput({
-            id: "value",
-            name: "Value",
-            type: types.string(),
-        });
-    },
-    run({ ctx }) {
-        localStorage.setItem(`value-${ctx.getInput("key")}`, ctx.getInput("value"));
-    }
-})
+  name: "Set Data",
+  variant: "Exec",
+  generateIO: (t) => {
+    t.dataInput({
+      id: "key",
+      name: "Key",
+      type: types.string(),
+    });
+    t.dataInput({
+      id: "value",
+      name: "Value",
+      type: types.string(),
+    });
+  },
+  run({ ctx }) {
+    localStorage.setItem(`value-${ctx.getInput("key")}`, ctx.getInput("value"));
+  },
+});
 
 pkg.createNonEventSchema({
-    name: "Get Data",
-    variant: "Pure",
-    generateIO: (t) => {
-        t.dataInput({
-            id: "key",
-            name: "Key",
-            type: types.string(),
-        });
-        t.dataOutput({
-            id: "exist",
-            name: "Exist",
-            type: types.bool(),
-        });
-        t.dataOutput({
-            id: "output",
-            name: "Data",
-            type: types.string(),
-        });
-    },
-    run({ ctx }) {
-        let data = localStorage.getItem(`value-${ctx.getInput("key")}`);
-        ctx.setOutput("exist", data !== null);
-        if (data !== null) ctx.setOutput("output", data);
-    }
+  name: "Get Data",
+  variant: "Pure",
+  generateIO: (t) => {
+    t.dataInput({
+      id: "key",
+      name: "Key",
+      type: types.string(),
+    });
+    t.dataOutput({
+      id: "exists",
+      name: "Exists",
+      type: types.bool(),
+    });
+    t.dataOutput({
+      id: "output",
+      name: "Data",
+      type: types.string(),
+    });
+  },
+  run({ ctx }) {
+    let data = localStorage.getItem(`value-${ctx.getInput("key")}`);
+    ctx.setOutput("exists", data !== null);
+    if (data !== null) ctx.setOutput("output", data);
+  },
 });

--- a/core/src/packages/logic.ts
+++ b/core/src/packages/logic.ts
@@ -37,15 +37,15 @@ pkg.createNonEventSchema({
   variant: "Base",
   run({ ctx }) {
     setTimeout(() => {
-      ctx.exec("output")
-    }, ctx.getInput("waitms"));
+      ctx.exec("output");
+    }, ctx.getInput("delay"));
   },
   generateIO(t) {
     t.execInput({
       id: "exec",
     });
     t.dataInput({
-      id: "waitms",
+      id: "delay",
       name: "Wait in ms",
       type: types.int(),
     });

--- a/core/src/packages/twitch/chat.ts
+++ b/core/src/packages/twitch/chat.ts
@@ -62,7 +62,7 @@ pkg.createNonEventSchema({
   variant: "Exec",
   generateIO: (t) => {
     t.dataInput({
-      id: "switch",
+      id: "enabled",
       type: types.bool(),
     });
   },
@@ -72,7 +72,7 @@ pkg.createNonEventSchema({
     if (!c) return;
 
     apiClient()?.chat.updateSettings(c.getUsername(), c.getUsername(), {
-      emoteOnlyModeEnabled: ctx.getInput("switch"),
+      emoteOnlyModeEnabled: ctx.getInput("enabled"),
     });
   },
 });

--- a/core/src/packages/twitch/eventsub.ts
+++ b/core/src/packages/twitch/eventsub.ts
@@ -134,7 +134,7 @@ pkg.createEventSchema({
       type: types.string(),
     });
     t.dataOutput({
-      id: "bannedUserName",
+      id: "bannedUserLogin",
       name: "Banned Username",
       type: types.string(),
     });
@@ -160,7 +160,7 @@ pkg.createEventSchema({
     ctx.setOutput("modId", data.event.moderator_user_id);
     ctx.setOutput("modName", data.event.moderator_user_login);
     ctx.setOutput("bannedUserID", data.event.user_id);
-    ctx.setOutput("bannedUserName", data.event.user_login);
+    ctx.setOutput("bannedUserLogin", data.event.user_login);
     ctx.setOutput("reason", data.event.reason);
     ctx.setOutput("permanent", data.event.is_permanent);
     ctx.setOutput("ends", data.event.ends_at);
@@ -870,7 +870,7 @@ pkg.createEventSchema({
       type: types.string(),
     });
     t.dataOutput({
-      id: "channelName",
+      id: "channelLogin",
       name: "Channel Name",
       type: types.string(),
     });
@@ -897,7 +897,7 @@ pkg.createEventSchema({
   },
   run({ ctx, data }) {
     ctx.setOutput("channelId", data.event.broadcaster_user_id);
-    ctx.setOutput("channelName", data.event.broadcaster_user_login);
+    ctx.setOutput("channelLogin", data.event.broadcaster_user_login);
     ctx.setOutput("title", data.event.title);
     ctx.setOutput("categoryId", data.event.category_id);
     ctx.setOutput("categoryName", data.event.category_name);
@@ -1172,13 +1172,13 @@ pkg.createEventSchema({
     });
     t.dataOutput({
       id: "userName",
-      name: "Username",
+      name: "UserLogin",
       type: types.string(),
     });
   },
   run({ ctx, data }) {
     ctx.setOutput("userID", data.event.user_id);
-    ctx.setOutput("userName", data.event.user_login);
+    ctx.setOutput("userLogin", data.event.user_login);
     ctx.exec("exec");
   },
 });

--- a/core/src/packages/twitch/helix.ts
+++ b/core/src/packages/twitch/helix.ts
@@ -378,7 +378,7 @@ pkg.createNonEventSchema({
     });
     t.dataOutput({
       name: "Redemption ID",
-      id: "redempId",
+      id: "redemptionId",
       type: types.string(),
     });
   },
@@ -401,7 +401,7 @@ pkg.createNonEventSchema({
         autoFulfill: ctx.getInput("autoFulfill"),
       });
       ctx.setOutput("success", true);
-      ctx.setOutput("redempId", data?.id);
+      ctx.setOutput("redemptionId", data?.id);
     } catch (error: any) {
       ctx.setOutput("success", false);
       ctx.setOutput("errorMessage", JSON.parse(error.body).message);
@@ -419,7 +419,7 @@ pkg.createNonEventSchema({
       type: types.int(),
     });
     t.dataInput({
-      id: "switch",
+      id: "enabled",
       type: types.bool(),
     });
   },
@@ -428,7 +428,7 @@ pkg.createNonEventSchema({
     if (!u) return;
 
     apiClient()?.chat.updateSettings(u.id, u.id, {
-      followerOnlyModeEnabled: ctx.getInput("switch"),
+      followerOnlyModeEnabled: ctx.getInput("enabled"),
       followerOnlyModeDelay: ctx.getInput("delay"),
     });
   },
@@ -444,7 +444,7 @@ pkg.createNonEventSchema({
       type: types.int(),
     });
     t.dataInput({
-      id: "switch",
+      id: "enabled",
       type: types.bool(),
     });
   },
@@ -453,7 +453,7 @@ pkg.createNonEventSchema({
     if (!u) return;
 
     apiClient()?.chat.updateSettings(u.id, u.id, {
-      slowModeEnabled: ctx.getInput("switch"),
+      slowModeEnabled: ctx.getInput("enabled"),
       slowModeDelay: ctx.getInput("delay"),
     });
   },
@@ -464,7 +464,7 @@ pkg.createNonEventSchema({
   variant: "Exec",
   generateIO: (t) => {
     t.dataInput({
-      id: "switch",
+      id: "enabled",
       type: types.bool(),
     });
   },
@@ -473,7 +473,7 @@ pkg.createNonEventSchema({
     if (!u) return;
 
     apiClient()?.chat.updateSettings(u.id, u.id, {
-      subscriberOnlyModeEnabled: ctx.getInput("switch"),
+      subscriberOnlyModeEnabled: ctx.getInput("enabled"),
     });
   },
 });
@@ -483,7 +483,7 @@ pkg.createNonEventSchema({
   variant: "Exec",
   generateIO: (t) => {
     t.dataInput({
-      id: "switch",
+      id: "enabled",
       type: types.bool(),
     });
   },
@@ -492,7 +492,7 @@ pkg.createNonEventSchema({
     if (!u) return;
 
     apiClient()?.chat.updateSettings(u.id, u.id, {
-      uniqueChatModeEnabled: ctx.getInput("switch"),
+      uniqueChatModeEnabled: ctx.getInput("enabled"),
     });
   },
 });
@@ -502,16 +502,15 @@ pkg.createNonEventSchema({
   variant: "Exec",
   generateIO: (t) => {
     t.dataInput({
-      id: "switch",
-      type: types.bool(),
+      id: "userId",
+      name: "User ID",
+      type: types.string(),
     });
   },
   run({ ctx }) {
     const u = user();
     if (!u) return;
 
-    apiClient()?.chat.updateSettings(u.id, u.id, {
-      subscriberOnlyModeEnabled: ctx.getInput("switch"),
-    });
+    apiClient()?.chat.shoutoutUser(u.id, ctx.getInput("userId"), u.id);
   },
 });

--- a/core/src/packages/utils.ts
+++ b/core/src/packages/utils.ts
@@ -71,11 +71,11 @@ pkg.createNonEventSchema({
   name: "String Length",
   variant: "Pure",
   run({ ctx }) {
-    ctx.setOutput("int", ctx.getInput<string>("haystack").length);
+    ctx.setOutput("int", ctx.getInput<string>("input").length);
   },
   generateIO(t) {
     t.dataInput({
-      id: "haystack",
+      id: "input",
       name: "String",
       type: types.string(),
     });
@@ -90,15 +90,15 @@ pkg.createNonEventSchema({
   name: "String",
   variant: "Pure",
   run({ ctx }) {
-    ctx.setOutput("stringOut", ctx.getInput("haystack"));
+    ctx.setOutput("output", ctx.getInput("input"));
   },
   generateIO(t) {
     t.dataInput({
-      id: "haystack",
+      id: "input",
       type: types.string(),
     });
     t.dataOutput({
-      id: "stringOut",
+      id: "output",
       type: types.string(),
     });
   },
@@ -108,15 +108,15 @@ pkg.createNonEventSchema({
   name: "Int",
   variant: "Pure",
   run({ ctx }) {
-    ctx.setOutput("intOut", ctx.getInput("haystack"));
+    ctx.setOutput("output", ctx.getInput("input"));
   },
   generateIO(t) {
     t.dataInput({
-      id: "haystack",
+      id: "input",
       type: types.int(),
     });
     t.dataOutput({
-      id: "intOut",
+      id: "output",
       type: types.int(),
     });
   },
@@ -126,15 +126,15 @@ pkg.createNonEventSchema({
   name: "Bool",
   variant: "Pure",
   run({ ctx }) {
-    ctx.setOutput("boolOut", ctx.getInput("haystack"));
+    ctx.setOutput("output", ctx.getInput("input"));
   },
   generateIO(t) {
     t.dataInput({
-      id: "haystack",
+      id: "input",
       type: types.bool(),
     });
     t.dataOutput({
-      id: "boolOut",
+      id: "output",
       type: types.bool(),
     });
   },
@@ -146,19 +146,17 @@ pkg.createNonEventSchema({
   run({ ctx }) {
     ctx.setOutput(
       "bool",
-      ctx
-        .getInput<string>("haystack")
-        .startsWith(ctx.getInput<string>("needle"))
+      ctx.getInput<string>("input").startsWith(ctx.getInput<string>("prefix"))
     );
   },
   generateIO(t) {
     t.dataInput({
-      id: "haystack",
+      id: "input",
       name: "String",
       type: types.string(),
     });
     t.dataInput({
-      id: "needle",
+      id: "prefix",
       name: "Starts With",
       type: types.string(),
     });
@@ -179,15 +177,15 @@ pkg.createNonEventSchema({
     const end =
       ctx.getInput<number>("end") !== 0
         ? ctx.getInput<number>("end")
-        : ctx.getInput<string>("string").length;
+        : ctx.getInput<string>("input").length;
     ctx.setOutput(
-      "stringOut",
-      ctx.getInput<string>("string").substring(start, end)
+      "output",
+      ctx.getInput<string>("input").substring(start, end)
     );
   },
   generateIO(t) {
     t.dataInput({
-      id: "string",
+      id: "input",
       type: types.string(),
     });
     t.dataInput({
@@ -201,7 +199,7 @@ pkg.createNonEventSchema({
       type: types.int(),
     });
     t.dataOutput({
-      id: "stringOut",
+      id: "output",
       type: types.string(),
     });
   },
@@ -211,15 +209,15 @@ pkg.createNonEventSchema({
   name: "String To Uppercase",
   variant: "Pure",
   run({ ctx }) {
-    ctx.setOutput("upper", ctx.getInput<string>("string").toUpperCase());
+    ctx.setOutput("output", ctx.getInput<string>("input").toUpperCase());
   },
   generateIO(t) {
     t.dataInput({
-      id: "string",
+      id: "input",
       type: types.string(),
     });
     t.dataOutput({
-      id: "upper",
+      id: "output",
       type: types.string(),
     });
   },
@@ -229,13 +227,13 @@ pkg.createNonEventSchema({
   name: "String is null",
   variant: "Pure",
   run({ ctx }) {
-    ctx.getInput("string")
+    ctx.getInput("input")
       ? ctx.setOutput("output", true)
       : ctx.setOutput("output", false);
   },
   generateIO(t) {
     t.dataInput({
-      id: "string",
+      id: "input",
       type: types.string(),
     });
     t.dataOutput({
@@ -249,15 +247,15 @@ pkg.createNonEventSchema({
   name: "String To Lowercase",
   variant: "Pure",
   run({ ctx }) {
-    ctx.setOutput("lower", ctx.getInput<string>("string").toLowerCase());
+    ctx.setOutput("output", ctx.getInput<string>("input").toLowerCase());
   },
   generateIO(t) {
     t.dataInput({
-      id: "string",
+      id: "input",
       type: types.string(),
     });
     t.dataOutput({
-      id: "lower",
+      id: "output",
       type: types.string(),
     });
   },
@@ -322,12 +320,12 @@ pkg.createNonEventSchema({
   variant: "Pure",
   run({ ctx }) {
     let number = Number(ctx.getInput<string>("string"));
-    ctx.setOutput("int", number);
-    ctx.setOutput("pass", !Number.isNaN(number));
+    ctx.setOutput("int", Math.floor(number));
+    ctx.setOutput("success", !Number.isNaN(number));
   },
   generateIO(t) {
     t.dataOutput({
-      id: "out",
+      id: "int",
       type: types.int(),
     });
     t.dataOutput({
@@ -336,110 +334,118 @@ pkg.createNonEventSchema({
       type: types.bool(),
     });
     t.dataInput({
-      id: "in",
+      id: "string",
       type: types.string(),
     });
   },
 });
 
 pkg.createNonEventSchema({
-  name: "Multiply",
+  name: "Multiply Ints",
   variant: "Pure",
   run({ ctx }) {
-    const numb = ctx.getInput<number>("num1") * ctx.getInput<number>("num2");
-    ctx.setOutput("outnum", numb);
+    const number = Math.floor(
+      ctx.getInput<number>("one") * ctx.getInput<number>("two")
+    );
+    ctx.setOutput("output", number);
   },
   generateIO(t) {
     t.dataInput({
-      id: "num1",
+      id: "one",
       type: types.int(),
     });
     t.dataInput({
-      id: "num2",
+      id: "two",
       type: types.int(),
     });
     t.dataOutput({
-      id: "outnum",
+      id: "output",
       type: types.int(),
     });
   },
 });
 
 pkg.createNonEventSchema({
-  name: "Divide",
+  name: "Divide Ints",
   variant: "Pure",
   run({ ctx }) {
-    const numb = ctx.getInput<number>("num1") / ctx.getInput<number>("num2");
-    ctx.setOutput("outnum", numb);
+    const number = Math.floor(
+      ctx.getInput<number>("one") / ctx.getInput<number>("two")
+    );
+    ctx.setOutput("output", number);
   },
   generateIO(t) {
     t.dataInput({
-      id: "num1",
+      id: "one",
       type: types.int(),
     });
     t.dataInput({
-      id: "num2",
+      id: "two",
       type: types.int(),
     });
     t.dataOutput({
-      id: "outnum",
+      id: "output",
       type: types.int(),
     });
   },
 });
 
 pkg.createNonEventSchema({
-  name: "Add",
+  name: "Add Ints",
   variant: "Pure",
   run({ ctx }) {
-    const numb = ctx.getInput<number>("num1") + ctx.getInput<number>("num2");
-    ctx.setOutput("outnum", numb);
+    const number = Math.floor(
+      ctx.getInput<number>("one") + ctx.getInput<number>("two")
+    );
+    ctx.setOutput("output", number);
   },
   generateIO(t) {
     t.dataInput({
-      id: "num1",
+      id: "one",
       type: types.int(),
     });
     t.dataInput({
-      id: "num2",
+      id: "two",
       type: types.int(),
     });
     t.dataOutput({
-      id: "outnum",
+      id: "output",
       type: types.int(),
     });
   },
 });
 
 pkg.createNonEventSchema({
-  name: "Subtract",
+  name: "Subtract Ints",
   variant: "Pure",
   run({ ctx }) {
-    const numb = ctx.getInput<number>("num1") - ctx.getInput<number>("num2");
-    ctx.setOutput("outnum", numb);
+    const numb = Math.floor(
+      ctx.getInput<number>("one") - ctx.getInput<number>("two")
+    );
+    ctx.setOutput("output", numb);
   },
   generateIO(t) {
     t.dataInput({
-      id: "num1",
+      id: "one",
       type: types.int(),
     });
     t.dataInput({
-      id: "num2",
+      id: "two",
       type: types.int(),
     });
     t.dataOutput({
-      id: "outnum",
+      id: "output",
       type: types.int(),
     });
   },
 });
 
 pkg.createNonEventSchema({
-  name: "Append",
+  name: "Append String",
   variant: "Pure",
   run({ ctx }) {
     ctx.setOutput(
-      "out",
+      "output",
       ctx.getInput<string>("one") + ctx.getInput<string>("two")
     );
   },
@@ -453,14 +459,14 @@ pkg.createNonEventSchema({
       type: types.string(),
     });
     t.dataOutput({
-      id: "out",
+      id: "output",
       type: types.string(),
     });
   },
 });
 
 pkg.createNonEventSchema({
-  name: "Round",
+  name: "Round Float",
   variant: "Pure",
   run({ ctx }) {
     const input = ctx.getInput<number>("input");


### PR DESCRIPTION
Mostly used "input" and "output" for nodes with single in/out (eg lowercase string) but wasn't sure if I should use that for (eg) String to Int, so have left those node IDs as their type names.