### PR TITLE
add retry logic on obs ws

### DIFF
--- a/packages/packages/src/obs/ctx.ts
+++ b/packages/packages/src/obs/ctx.ts
@@ -39,6 +39,11 @@ export function createCtx() {
         state: "disconnected",
         password: instance.password,
       });
+
+      setTimeout(() => {
+        console.log("disconnect running");
+        connectInstance(ip);
+      }, 10000);
     }
 
     const obs = new OBS();


### PR DESCRIPTION
added a retry after 10seconds on each setDisconnect call which is self referential so it should just loop indefinitely also does when obs disconnects itself 