### PR TITLE
Fix audio urls on Linux and macOS

### DIFF
--- a/apps/desktop/src/Editor.tsx
+++ b/apps/desktop/src/Editor.tsx
@@ -47,8 +47,7 @@ const wsProvider = createWsProvider({
 [
 	() =>
 		pkgs.audio.pkg({
-			prepareURL: (url: string) =>
-				convertFileSrc(url).replace("asset://", "https://asset."),
+			prepareURL: (url: string) => convertFileSrc(url),
 		}),
 	pkgs.discord.pkg,
 	() =>


### PR DESCRIPTION
Refering to Tauri's internals of [convertFileSrc](https://github.com/tauri-apps/tauri/blob/a0841d509abc43b62bb7c755e8727f3f461862d1/core/tauri/scripts/core.js#L12) we should not need to do the manual `.replace`.