### PR TITLE
Add "Send Chat Reply" for Twitch

### DIFF
--- a/packages/packages/src/twitch/chat.ts
+++ b/packages/packages/src/twitch/chat.ts
@@ -172,6 +172,64 @@ export function register(pkg: Package, { chat }: Ctx) {
 		},
 	});
 
+	pkg.createSchema({
+		name: "Send Chat Reply",
+		type: "exec",
+		properties: defaultProperties,
+		createIO: ({ ctx, properties, io }) => {
+			const state = () =>
+				ctx
+					.getProperty(properties.sender as DefaultProperties["sender"])
+					.andThen((sender) => Maybe(chat.clients.get(sender.data.id)))
+					.filter((s) => s.status === "connected");
+
+			const data = () =>
+				[
+					state().expect("No chat client connected"),
+					ctx
+						.getProperty(properties.channel as DefaultProperties["channel"])
+						.expect("Channel not provided"),
+				] as const;
+
+			createEffect(
+				on(data, ([state, channel]) => {
+					const channelLowercase = channel.toLowerCase();
+
+					state.channelListenerCounts[channelLowercase] ??= 0;
+					state.channelListenerCounts[channelLowercase] += 1;
+
+					onCleanup(() => {
+						if (state.channelListenerCounts[channelLowercase] !== undefined)
+							state.channelListenerCounts[channelLowercase] -= 1;
+					});
+				}),
+			);
+
+			return {
+				message: io.dataInput({
+					id: "message",
+					name: "Message",
+					type: t.string(),
+				}),
+				parent_id: io.dataInput({
+					id: "parent_id",
+					name: "Parent Message ID",
+					type: t.string(),
+				}),
+				data,
+			};
+		},
+		run({ ctx, io }) {
+			const [state, channel] = io.data();
+
+			return state.client.reply(
+				channel,
+				ctx.getInput(io.message),
+				ctx.getInput(io.parent_id),
+			);
+		},
+	});
+
 	type ListenerType<T> = [T] extends [(...args: infer U) => any]
 		? U
 		: [T] extends [never]


### PR DESCRIPTION
Creates a "Send Chat Reply" node for Twitch that takes in a parent message ID to reply to. I originally incorporated this into the original Send Chat Message node but didn't want to deal with making users use Make Some to satisfy the Option requirement.

Uses tmi.js' `reply()` function: https://github.com/tmijs/tmi.js/commit/7d92df25e3b3057f9446a536f4b877a7109298e4